### PR TITLE
Ignore testing files when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+example/
+*.test.js


### PR DESCRIPTION
The currently published version of this lib has the example folder including it's node_modules published,

This is causing our security scanner to raise an issue because the mime dependency has a vulnerability in it.

Would it be possible to publish a new version without the example folder?

Output of publish dry run now:
```
npm notice 📦  @hmcts/cookie-encrypter@1.0.1
npm notice === Tarball Contents ===
npm notice 4.4kB index.js
npm notice 712B  package.json
npm notice 644B  CHANGELOG.md
npm notice 2.7kB README.md
```